### PR TITLE
feat: замена afxres.h на WinResRc.h для сборки решения без ATL/MFC

### DIFF
--- a/src/3rd party/openal/OpenAL-Windows/Router/OpenAL32.rc
+++ b/src/3rd party/openal/OpenAL-Windows/Router/OpenAL32.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "WinresRc.h"
+#define IDC_STATIC (-1)
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/src/xrCPU_Pipe/xrCPU_Pipe.rc
+++ b/src/xrCPU_Pipe/xrCPU_Pipe.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "WinresRc.h"
+#define IDC_STATIC (-1)
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/src/xrCore/xrCore.rc
+++ b/src/xrCore/xrCore.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "WinresRc.h"
+#define IDC_STATIC (-1)
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/src/xrEngine/resource.rc
+++ b/src/xrEngine/resource.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "WinresRc.h"
+#define IDC_STATIC (-1)
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS


### PR DESCRIPTION
Для успешной компиляции решения, требовалось подключить актуальные версии библиотек ATL/MFC.
Данный PR отменяет данную необходимость, позволяя собрать решение без указанных библиотек.